### PR TITLE
Add gpuCI Jenkins Build Scripts to Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Common build environment used by gpuCI for building libgdf/pygdf
 
 ## Usage
 
-Updates pushed to `master` will trigger 
-[builds](http://18.191.94.64/job/goai-docker-container-builder/) of the Docker 
+### Build Environment Dockerfile
+
+Updates pushed to `master` will trigger
+[builds](http://18.191.94.64/job/goai-docker-container-builder/) of the Docker
 containers used for the [gpuCI service](http://18.191.94.64/)
+
+### Build Scripts
+
+1. Add or modify scripts to `build-scripts/` folder saving file with the name of
+the job appended with `.sh`
+2. Change the **Execute Shell** step in the Jenkins job to the following:
+```
+echo -e "\n\n>>>> Cloning build scripts...\n\n"
+git clone https://github.com/gpuopenanalytics/gpuci-build-environment.git
+bash gpuci-build-environment/build-scripts/${JOB_BASE_NAME}.sh
+```
+3. Trigger new build after changes are pushed to master to use new scripts

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # gpuci-build-environment
 
-[![Build Status](http://18.191.94.64/buildStatus/icon?job=goai-docker-container-builder)](http://18.191.94.64/job/goai-docker-container-builder/)
-
 Common build environment used by gpuCI for building libgdf/pygdf
 
 ## Usage
 
 ### Build Environment Dockerfile
+
+[![Build Status](http://18.191.94.64/buildStatus/icon?job=goai-docker-container-builder)](http://18.191.94.64/job/goai-docker-container-builder/)
 
 Updates pushed to `master` will trigger
 [builds](http://18.191.94.64/job/goai-docker-container-builder/) of the Docker

--- a/build-scripts/libgdf-master.sh
+++ b/build-scripts/libgdf-master.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+function logger() {
+  echo -e "\n>>>> $@\n"
+}
+
+logger "Check environment..."
+env
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "Patch conda env..."
+cat conda_environments/dev_py35.yml | grep -v "cudatoolkit" > libgdf_dev.yml
+
+logger "Create conda env..."
+rm -rf /home/jenkins/.conda/envs/libgdf_dev
+conda env create --name libgdf_dev --file libgdf_dev.yml
+
+logger "Activate conda env..."
+source activate libgdf_dev
+
+logger "Check versions..."
+python --version
+gcc --version
+g++ --version
+conda list
+
+logger "Run cmake libgdf..."
+rm -rf build
+mkdir build
+cd build
+cmake .. -DHASH_JOIN=ON
+
+logger "Run make libgdf..."
+make -j install
+
+logger "Install libgdf for Python..."
+make -j copy_python
+python setup.py install
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "GoogleTest for libgdf..."
+make -j test
+
+logger "Python py.test for libgdf..."
+cd ${WORKSPACE}
+py.test --cache-clear --junitxml=junit.xml -v

--- a/build-scripts/libgdf-prb.sh
+++ b/build-scripts/libgdf-prb.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+function logger() {
+  echo -e "\n>>>> $@\n"
+}
+
+logger "Check environment..."
+env
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "Patch conda env..."
+cat conda_environments/dev_py35.yml | grep -v "cudatoolkit" > libgdf_dev.yml
+
+logger "Create conda env..."
+rm -rf /home/jenkins/.conda/envs/libgdf_dev
+conda env create --name libgdf_dev --file libgdf_dev.yml
+
+logger "Activate conda env..."
+source activate libgdf_dev
+
+logger "Check versions..."
+python --version
+gcc --version
+g++ --version
+conda list
+
+logger "Run cmake libgdf..."
+rm -rf build
+mkdir build
+cd build
+cmake .. -DHASH_JOIN=ON
+
+logger "Run make libgdf..."
+make -j install
+
+logger "Install libgdf for Python..."
+make -j copy_python
+python setup.py install
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "GoogleTest for libgdf..."
+make -j test
+
+logger "Python py.test for libgdf..."
+cd ${WORKSPACE}
+py.test --cache-clear --junitxml=junit.xml -v

--- a/build-scripts/pygdf-master.sh
+++ b/build-scripts/pygdf-master.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+CC=/usr/bin/gcc
+CXX=/usr/bin/g++
+LIBGDF_REPO=https://github.com/gpuopenanalytics/libgdf
+NUMBA_VERSION=0.40.0
+NUMPY_VERSION=1.14.5
+PANDAS_VERSION=0.20.3
+PYTHON_VERSION=3.5
+PYARROW_VERSION=0.10.0
+
+function logger() {
+  echo -e "\n>>>> $@\n"
+}
+
+logger "Check environment..."
+env
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "Create conda env..."
+rm -rf /home/jenkins/.conda/envs/pygdf
+conda create -n pygdf python=${PYTHON_VERSION}
+conda install -n pygdf -y -c numba -c conda-forge -c defaults \
+  numba=${NUMBA_VERSION} \
+  numpy=${NUMPY_VERSION} \
+  pandas=${PANDAS_VERSION} \
+  pyarrow=${PYARROW_VERSION} \
+  pytest
+
+logger "Activate conda env..."
+source activate pygdf
+
+logger "Check versions..."
+python --version
+gcc --version
+g++ --version
+conda list
+
+logger "Clone libgdf..."
+rm -rf $WORKSPACE/libgdf
+git clone --recurse-submodules ${LIBGDF_REPO} $WORKSPACE/libgdf
+
+logger "Build libgdf..."
+mkdir -p $WORKSPACE/libgdf/build
+cd $WORKSPACE/libgdf/build
+logger "Run cmake libgdf..."
+cmake ..
+
+logger "Clean up make..."
+make clean
+
+logger "Install libgdf..."
+make -j install
+
+logger "Install libgdf for Python..."
+make -j copy_python
+python setup.py install
+
+logger "Build pygdf..."
+cd $WORKSPACE
+python setup.py install
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "Test pygdf..."
+py.test --cache-clear --junitxml=junit.xml --ignore=libgdf -v

--- a/build-scripts/pygdf-prb.sh
+++ b/build-scripts/pygdf-prb.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+CC=/usr/bin/gcc
+CXX=/usr/bin/g++
+LIBGDF_REPO=https://github.com/gpuopenanalytics/libgdf
+NUMBA_VERSION=0.40.0
+NUMPY_VERSION=1.14.5
+PANDAS_VERSION=0.20.3
+PYTHON_VERSION=3.5
+PYARROW_VERSION=0.10.0
+
+function logger() {
+  echo -e "\n>>>> $@\n"
+}
+
+logger "Check environment..."
+env
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "Create conda env..."
+rm -rf /home/jenkins/.conda/envs/pygdf
+conda create -n pygdf python=${PYTHON_VERSION}
+conda install -n pygdf -y -c numba -c conda-forge -c defaults \
+  numba=${NUMBA_VERSION} \
+  numpy=${NUMPY_VERSION} \
+  pandas=${PANDAS_VERSION} \
+  pyarrow=${PYARROW_VERSION} \
+  pytest
+
+logger "Activate conda env..."
+source activate pygdf
+
+logger "Check versions..."
+python --version
+gcc --version
+g++ --version
+conda list
+
+logger "Clone libgdf..."
+rm -rf $WORKSPACE/libgdf
+git clone --recurse-submodules ${LIBGDF_REPO} $WORKSPACE/libgdf
+
+logger "Build libgdf..."
+mkdir -p $WORKSPACE/libgdf/build
+cd $WORKSPACE/libgdf/build
+logger "Run cmake libgdf..."
+cmake ..
+
+logger "Clean up make..."
+make clean
+
+logger "Install libgdf..."
+make -j install
+
+logger "Install libgdf for Python..."
+make -j copy_python
+python setup.py install
+
+logger "Build pygdf..."
+cd $WORKSPACE
+python setup.py install
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "Test pygdf..."
+py.test --cache-clear --junitxml=junit.xml --ignore=libgdf -v


### PR DESCRIPTION
This allows for dynamic updates to the gpuCI tests run on http://gpuci.gpuopenanalytics.com until the new pipeline and Jenkinsfile methods are available.