### PR TITLE
Generate XML Reports for GoogleTests for Jenkins CI

### DIFF
--- a/build-scripts/libgdf-master.sh
+++ b/build-scripts/libgdf-master.sh
@@ -43,8 +43,9 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "GoogleTest for libgdf..."
-make -j test
+GTEST_OUTPUT="xml:${WORKSPACE}/test-results/" make -j test
 
 logger "Python py.test for libgdf..."
 cd ${WORKSPACE}
 py.test --cache-clear --junitxml=junit.xml -v
+cp junit.xml $WORKSPACE/test-results

--- a/build-scripts/libgdf-prb.sh
+++ b/build-scripts/libgdf-prb.sh
@@ -43,8 +43,9 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "GoogleTest for libgdf..."
-make -j test
+GTEST_OUTPUT="xml:${WORKSPACE}/test-results/" make -j4 test
 
 logger "Python py.test for libgdf..."
 cd ${WORKSPACE}
 py.test --cache-clear --junitxml=junit.xml -v
+cp junit.xml $WORKSPACE/test-results


### PR DESCRIPTION
For Jenkins to display the results of the GoogleTests along with the Python tests already found at: http://gpuci.gpuopenanalytics.com/job/libgdf-master/lastCompletedBuild/testReport/python.tests/